### PR TITLE
Sort image tags by version instead of purely alphabetically

### DIFF
--- a/view-private-registry
+++ b/view-private-registry
@@ -18,7 +18,7 @@ find $PERSISTENT_REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY -print | \
 	sed -e 's/\/_manifests\/tags\//:/' | \
 	sed -e 's/\/current//' | \
 	sed -e 's/^.*repositories\//	/' | \
-	sort > /tmp/a1
+	sort -V > /tmp/a1
 cat /tmp/a1
 wc -l /tmp/a1 > /tmp/a2
 echo "Number of images:	`cat /tmp/a2 | awk {'print $1'}`"


### PR DESCRIPTION
This helps when your image tags are versioned:

```
myrepo:foo-1
myrepo:foo-11
myrepo:foo-5
```
becomes
```
myrepo:foo-1
myrepo:foo-5
myrepo:foo-11
```